### PR TITLE
Add FerryAPI to the list of AI services

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Where to get API keys.
 - [DeepInfra](https://deepinfra.com/dash/api_keys) — Hosted open-weight inference.
 - [DeepSeek](https://platform.deepseek.com) — DeepSeek-V3 and R1 reasoning models.
 - [ElevenLabs](https://elevenlabs.io/app/settings/api-keys) — Text-to-speech and voice cloning.
+- [FerryAPI](https://www.ferryapi.io/?utm_source=github&utm_medium=directory&utm_campaign=7day_growth) — OpenAI-compatible gateway for DeepSeek, Qwen, Kimi, and MiMo.
 - [Fireworks AI](https://fireworks.ai/account/api-keys) — Fast open-model hosting.
 - [Google AI Studio](https://aistudio.google.com/app/apikey) — Gemini family keys with a free tier.
 - [Groq](https://console.groq.com/keys) — Free-tier LPU inference for open models.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Where to get API keys.
 - [DeepInfra](https://deepinfra.com/dash/api_keys) — Hosted open-weight inference.
 - [DeepSeek](https://platform.deepseek.com) — DeepSeek-V3 and R1 reasoning models.
 - [ElevenLabs](https://elevenlabs.io/app/settings/api-keys) — Text-to-speech and voice cloning.
-- [FerryAPI](https://www.ferryapi.io/?utm_source=github&utm_medium=directory&utm_campaign=7day_growth) — OpenAI-compatible gateway for DeepSeek, Qwen, Kimi, and MiMo.
+- [FerryAPI](https://www.ferryapi.io/) — OpenAI-compatible gateway for DeepSeek, Qwen, Kimi, and MiMo.
 - [Fireworks AI](https://fireworks.ai/account/api-keys) — Fast open-model hosting.
 - [Google AI Studio](https://aistudio.google.com/app/apikey) — Gemini family keys with a free tier.
 - [Groq](https://console.groq.com/keys) — Free-tier LPU inference for open models.


### PR DESCRIPTION
Adds FerryAPI to the Providers section.

- Live URL: https://www.ferryapi.io/
- API key/docs: https://www.ferryapi.io/docs
- Supported provider families shown on the live site: DeepSeek, Qwen, Kimi, and MiMo
- Category fit: FerryAPI issues API keys for an OpenAI-compatible AI API gateway.

I kept the entry factual, under 100 chars, and placed it alphabetically.