### PR TITLE
docs: add AI Router provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Where to get API keys.
 - [Groq](https://console.groq.com/keys) — Free-tier LPU inference for open models.
 - [Hugging Face](https://huggingface.co/settings/tokens) — Inference API across thousands of hosted models.
 - [Mistral AI](https://console.mistral.ai/api-keys) — Mistral and Codestral models, EU-hosted.
+- [AI Router](https://ai-router.dev/register) — Create an OpenAI-compatible API key for GPT workflows with usage visibility.
 - [OpenAI](https://platform.openai.com/api-keys) — GPT, DALL·E, Whisper, and TTS.
 - [OpenRouter](https://openrouter.ai/keys) — One key for hundreds of models across providers.
 - [Perplexity](https://www.perplexity.ai/settings/api) — Sonar search-grounded models.


### PR DESCRIPTION
## Summary
- Add AI Router to the Providers section in alphabetical order.

## Directory fit
- Live URL: https://ai-router.dev/register
- Users register and create their own AI Router API key in the /keys workspace.
- The key is used with the OpenAI-compatible base URL: https://api.ai-router.dev/v1.
- The service provides GPT workflow access with per-key usage visibility.
- The public site is live and actively maintained.

The entry intentionally makes no free-tier, model-price, or unsupported capability claims.