### PR TITLE
Added Rewire Text to writing and research section

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Built-in BYOK in commercial tools.
 - [Novel](https://github.com/steven-tey/novel) — Notion-style editor with AI commands.
 - [OpenGrammar](https://github.com/swadhinbiswas/opengrammar) — Open-source Grammarly alternative.
 - [Perplexica](https://github.com/ItzCrazyKns/Perplexica) — Open-source Perplexity-style search.
+- [Rewire Text](https://sunsetmesasoftware.com/rewire-text/) — Windows/macOS tool to transform text in any app using a hotkey. Supports BYOK and local AI providers.
 
 ## Translation
 


### PR DESCRIPTION
Added "Rewire Text" to the "Writing and research" section.
(Note that it also supports translation as one of many AI transforms, so it could also fit into that section; but I went with the more general one.)

Rewire Text supports all prominent providers via a dedicated drop-down entry (currently Anthropic, Gemini, OpenAI, xAI Grok, OpenRouter), as well as any provider with an OpenAI compatible API. For local AI, it supports Ollama, LM Studio, and llama.cpp (and the OpenAI compatible API should support others as well).

Single-purchase, no subscription.
Full disclosure: I'm the developer.