### PR TITLE
Add Engaggit - AI-powered Reddit lead gen tool with BYOK

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Built-in BYOK in commercial tools.
 - [OpenGrammar](https://github.com/swadhinbiswas/opengrammar) — Open-source Grammarly alternative.
 - [Perplexica](https://github.com/ItzCrazyKns/Perplexica) — Open-source Perplexity-style search.
 - [Rewire Text](https://sunsetmesasoftware.com/rewire-text/) — Windows/macOS tool to transform text in any app using a hotkey. Supports BYOK and local AI providers.
+- [Engaggit](https://engaggit.com/) — AI-powered Reddit lead generation and research tool that runs 100% on your machine
 
 ## Translation
 


### PR DESCRIPTION
Disclosure: I am the author of Engaggit.

Live URL: https://engaggit.com/

How the user supplies their key: In the app’s settings panel, the user chooses an AI provider and enters their own API key (or configures a local endpoint like Ollama). Keys are stored with OS-level encryption and never leave the user’s machine.

Supported providers: OpenAI, Gemini, DeepSeek, Grok, OpenRouter, Ollama, and any custom OpenAI-compatible endpoint.

Engaggit is a desktop app that runs 100% on the user’s computer, scanning Reddit and using the user’s own AI API key to score posts and generate comment drafts. It meets all BYOK criteria - no subscription markup, no key resale, full privacy.