### PR TITLE
Add Infersia to Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Where to get API keys.
 - [Google AI Studio](https://aistudio.google.com/app/apikey) — Gemini family keys with a free tier.
 - [Groq](https://console.groq.com/keys) — Free-tier LPU inference for open models.
 - [Hugging Face](https://huggingface.co/settings/tokens) — Inference API across thousands of hosted models.
+- [Infersia](https://infersia.com/dashboard/keys) — Hosted open-weight inference with the served quantisation published.
 - [Mistral AI](https://console.mistral.ai/api-keys) — Mistral and Codestral models, EU-hosted.
 - [OpenAI](https://platform.openai.com/api-keys) — GPT, DALL·E, Whisper, and TTS.
 - [OpenRouter](https://openrouter.ai/keys) — One key for hundreds of models across providers.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Where to get API keys.
 - [Google AI Studio](https://aistudio.google.com/app/apikey) — Gemini family keys with a free tier.
 - [Groq](https://console.groq.com/keys) — Free-tier LPU inference for open models.
 - [Hugging Face](https://huggingface.co/settings/tokens) — Inference API across thousands of hosted models.
-- [Infersia](https://infersia.com/dashboard/keys) — Hosted open-weight inference with the served quantisation published.
+- [Infersia](https://infersia.com/dashboard/keys) — Hosted open-weight inference with a free tier and published quantisation.
 - [Mistral AI](https://console.mistral.ai/api-keys) — Mistral and Codestral models, EU-hosted.
 - [OpenAI](https://platform.openai.com/api-keys) — GPT, DALL·E, Whisper, and TTS.
 - [OpenRouter](https://openrouter.ai/keys) — One key for hundreds of models across providers.


### PR DESCRIPTION
Adds Infersia to the **Providers** section.

**Affiliation:** I run Infersia — disclosing per CONTRIBUTING.

### Provider-specific requirements

- **API key page:** https://infersia.com/dashboard/keys (sign up at https://infersia.com/signup, keys are self-serve immediately after)
- **Models:** open-weight only — DeepSeek V4 Flash 0731 (1M context), StepFun Step 3.7 Flash (262K, vision), Qwen3.6 35B-A3B, Qwen3 14B, Qwen3 8B. Full catalogue with live latency and uptime at https://infersia.com/models
- **Free tier:** none at present. New accounts get 10% extra credit on their first top-up; minimum top-up is $10.

### PR checklist

- **Live URL:** https://infersia.com — API at `https://api.infersia.com/v1`
- **How users supply their key:** standard OpenAI-compatible bearer auth. Point any OpenAI SDK at the base URL with an `isk-v1-…` key:
  ```python
  client = OpenAI(base_url="https://api.infersia.com/v1", api_key="isk-v1-...")
  ```
  Works unmodified with the official `openai` SDKs, and with any app in this list that accepts a custom OpenAI-compatible endpoint.
- **Supported clients:** anything OpenAI-compatible — verified in production against OpenClaw, and the endpoint is exercised by the official `openai` Python/JS SDKs in CI (streaming, tool calls, structured output, prefix caching).
- **Active maintenance:** yes — actively developed, models added and priced weekly.

### Why it isn't a key-resale service

Per the exclusion criteria: Infersia is not a relay over shared third-party accounts. We rent GPUs and run the weights ourselves under vLLM, and each endpoint publishes the exact quantisation served (MXFP4, NVFP4, AWQ int4), the hardware class, measured latency and 30-day uptime. That disclosure is the reason the entry mentions quantisation — it is the thing that distinguishes hosts of the same open-weight model.

Entry is alphabetical between Hugging Face and Mistral AI, under 100 chars, no marketing language, canonical URL without trackers. Contribution released under CC0.
